### PR TITLE
Fix RequireAny failing to validate when static fields are present

### DIFF
--- a/src/main/java/net/barrage/tegridy/validation/validator/RequireAnyValidator.java
+++ b/src/main/java/net/barrage/tegridy/validation/validator/RequireAnyValidator.java
@@ -3,6 +3,7 @@ package net.barrage.tegridy.validation.validator;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import jakarta.validation.constraints.NotNull;
+import java.lang.reflect.Modifier;
 import net.barrage.tegridy.validation.annotation.RequireAny;
 
 /**
@@ -20,6 +21,11 @@ public class RequireAnyValidator implements ConstraintValidator<RequireAny, Obje
   @Override
   public boolean isValid(@NotNull Object o, ConstraintValidatorContext context) {
     for (var field : o.getClass().getDeclaredFields()) {
+      // Skip static fields
+      if (Modifier.isStatic(field.getModifiers())) {
+        continue;
+      }
+
       field.setAccessible(true);
       try {
         var value = field.get(o);

--- a/src/test/java/validation/RequireAnyTests.java
+++ b/src/test/java/validation/RequireAnyTests.java
@@ -45,6 +45,30 @@ public class RequireAnyTests {
     assertEquals(expectedMessage, violations.iterator().next().getMessage());
   }
 
+  @Test
+  void correctlyFailsWithStaticFields() {
+    var foo = new FooStatic();
+    var violations = validator.validate(foo);
+    String expectedMessage = "Object must have at least one non-null field";
+    assertEquals(expectedMessage, violations.iterator().next().getMessage());
+  }
+
+  @Test
+  void correctlyPassesWithStaticFields() {
+    var foo = new FooStatic("foo", null);
+    var violations = validator.validate(foo);
+    assertTrue(violations.isEmpty());
+  }
+
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @RequireAny
+  static class FooStatic {
+    String foo;
+    String bar;
+    static String BAR = "bar";
+  }
+
   @AllArgsConstructor
   @NoArgsConstructor
   @RequireAny


### PR DESCRIPTION
If any static fields are present in a class, the validation fails.
The issue laid in sticking some constants used for validation in the same class, since we cannot have constants outside a class no sir